### PR TITLE
rename schema method

### DIFF
--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -27,9 +27,23 @@ module ActionController
     # Default values are `:json`, `:js`, `:xml`.
     RENDERERS = Set.new
 
+    module DeprecatedEscapeJsonResponses # :nodoc:
+      def escape_json_responses=(value)
+        if value
+          ActionController.deprecator.warn(<<~MSG.squish)
+            Setting action_controller.escape_json_responses = true is deprecated and will have no effect in Rails 8.2.
+            Set it to `false`, or remove the config.
+          MSG
+        end
+        super
+      end
+    end
+
     included do
       class_attribute :_renderers, default: Set.new.freeze
-      class_attribute :escape_json_responses, instance_accessor: false, default: true
+      class_attribute :escape_json_responses, instance_writer: false, instance_accessor: false, default: true
+
+      singleton_class.prepend DeprecatedEscapeJsonResponses
     end
 
     # Used in ActionController::Base and ActionController::API to include all

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -133,18 +133,5 @@ module ActionController
         ActionController::TestCase.executor_around_each_request = app.config.active_support.executor_around_test_case
       end
     end
-
-    initializer "action_controller.escape_json_responses_deprecated_warning" do
-      config.after_initialize do
-        ActiveSupport.on_load(:action_controller) do
-          if ActionController::Base.escape_json_responses
-            ActionController.deprecator.warn(<<~MSG.squish)
-              Setting action_controller.escape_json_responses = true is deprecated and will have no effect in Rails 8.2.
-              Set it to `false` or use `config.load_defaults(8.1)`.
-            MSG
-          end
-        end
-      end
-    end
   end
 end

--- a/actionpack/test/controller/render_json_test.rb
+++ b/actionpack/test/controller/render_json_test.rb
@@ -122,10 +122,96 @@ class RenderJsonTest < ActionController::TestCase
   end
 
   def test_render_json_with_new_default_and_without_callback_does_not_escape_js_chars
-    TestController.with(escape_json_responses: false) do
-      get :render_json_unsafe_chars_without_callback
-      assert_equal %({"hello":"\u2028\u2029<script>"}), @response.body
-      assert_equal "application/json", @response.media_type
+    msg = <<~MSG.squish
+      Setting action_controller.escape_json_responses = true is deprecated and will have no effect in Rails 8.2.
+      Set it to `false`, or remove the config.
+    MSG
+
+    assert_deprecated(msg, ActionController.deprecator) do
+      TestController.with(escape_json_responses: false) do
+        get :render_json_unsafe_chars_without_callback
+        assert_equal %({"hello":"\u2028\u2029<script>"}), @response.body
+        assert_equal "application/json", @response.media_type
+      end
+    end
+  end
+
+  def test_render_json_with_optional_escape_option_is_not_deprecated
+    @before_escape_json_responses = @controller.class.escape_json_responses
+
+    assert_not_deprecated(ActionController.deprecator) do
+      @controller.class.escape_json_responses = false
+    end
+
+    get :render_json_unsafe_chars_without_callback
+    assert_equal %({"hello":"\u2028\u2029<script>"}), @response.body
+    assert_equal "application/json", @response.media_type
+  ensure
+    ActionController.deprecator.silence do
+      @controller.class.escape_json_responses = @before_escape_json_responses
+    end
+  end
+
+  def test_render_json_with_redundant_escape_option_is_deprecated
+    @before_escape_json_responses = @controller.class.escape_json_responses
+
+    msg = <<~MSG.squish
+      Setting action_controller.escape_json_responses = true is deprecated and will have no effect in Rails 8.2.
+      Set it to `false`, or remove the config.
+    MSG
+
+    assert_deprecated(msg, ActionController.deprecator) do
+      @controller.class.escape_json_responses = true
+    end
+
+    get :render_json_unsafe_chars_without_callback
+    assert_equal '{"hello":"\\u2028\\u2029\\u003cscript\\u003e"}', @response.body
+    assert_equal "application/json", @response.media_type
+  ensure
+    ActionController.deprecator.silence do
+      @controller.class.escape_json_responses = @before_escape_json_responses
+    end
+  end
+
+  def test_set_escape_json_responses_class_method_is_deprecated
+    @before_escape_json_responses = @controller.class.escape_json_responses
+
+    msg = <<~MSG.squish
+      Setting action_controller.escape_json_responses = true is deprecated and will have no effect in Rails 8.2.
+      Set it to `false`, or remove the config.
+    MSG
+
+    assert_deprecated(msg, ActionController.deprecator) do
+      @controller.class.escape_json_responses = true
+    end
+
+    get :render_json_unsafe_chars_without_callback
+    assert_equal '{"hello":"\\u2028\\u2029\\u003cscript\\u003e"}', @response.body
+    assert_equal "application/json", @response.media_type
+  ensure
+    ActionController.deprecator.silence do
+      @controller.class.escape_json_responses = @before_escape_json_responses
+    end
+  end
+
+  def test_set_escape_json_responses_controller_method_is_deprecated
+    @before_escape_json_responses = @controller.class.escape_json_responses
+
+    msg = <<~MSG.squish
+      Setting action_controller.escape_json_responses = true is deprecated and will have no effect in Rails 8.2.
+      Set it to `false`, or remove the config.
+    MSG
+
+    assert_deprecated(msg, ActionController.deprecator) do
+      @controller.class.escape_json_responses = true
+    end
+
+    get :render_json_unsafe_chars_without_callback
+    assert_equal '{"hello":"\\u2028\\u2029\\u003cscript\\u003e"}', @response.body
+    assert_equal "application/json", @response.media_type
+  ensure
+    ActionController.deprecator.silence do
+      @controller.class.escape_json_responses = @before_escape_json_responses
     end
   end
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `rename_schema` method for PostgreSQL.
+
+    *T S Vallender*
+
 *   Implement support for deprecating associations:
 
     ```ruby

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -2035,7 +2035,7 @@ module ActiveRecord
           hm_options[:through] = middle_reflection.name
           hm_options[:source] = join_model.right_reflection.name
 
-          [:before_add, :after_add, :before_remove, :after_remove, :autosave, :validate, :join_table, :class_name, :extend, :strict_loading].each do |k|
+          [:before_add, :after_add, :before_remove, :after_remove, :autosave, :validate, :join_table, :class_name, :extend, :strict_loading, :deprecated].each do |k|
             hm_options[k] = options[k] if options.key?(k)
           end
 

--- a/activerecord/lib/active_record/associations/deprecation.rb
+++ b/activerecord/lib/active_record/associations/deprecation.rb
@@ -79,12 +79,7 @@ module ActiveRecord::Associations::Deprecation # :nodoc:
       end
 
       def user_facing_reflection(reflection)
-        case reflection.parent_reflection
-        when ActiveRecord::Reflection::HasAndBelongsToManyReflection
-          reflection.parent_reflection
-        else
-          reflection
-        end
+        reflection.active_record.reflect_on_association(reflection.name)
       end
   end
 

--- a/activerecord/lib/active_record/associations/deprecation.rb
+++ b/activerecord/lib/active_record/associations/deprecation.rb
@@ -37,6 +37,8 @@ module ActiveRecord::Associations::Deprecation # :nodoc:
     end
 
     def report(reflection, context:)
+      reflection = user_facing_reflection(reflection)
+
       message = +"The association #{reflection.active_record}##{reflection.name} is deprecated, #{context}"
       message << " (#{backtrace_cleaner.first_clean_frame})"
 
@@ -74,6 +76,15 @@ module ActiveRecord::Associations::Deprecation # :nodoc:
 
       def set_backtrace_supports_array_of_locations?
         @backtrace_supports_array_of_locations ||= Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
+      end
+
+      def user_facing_reflection(reflection)
+        case reflection.parent_reflection
+        when ActiveRecord::Reflection::HasAndBelongsToManyReflection
+          reflection.parent_reflection
+        else
+          reflection
+        end
       end
   end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -279,6 +279,11 @@ module ActiveRecord
           execute "DROP SCHEMA#{' IF EXISTS' if options[:if_exists]} #{quote_schema_name(schema_name)} CASCADE"
         end
 
+        # Renames the schema for the given schema name.
+        def rename_schema(schema_name, new_name)
+          execute "ALTER SCHEMA #{quote_schema_name(schema_name)} RENAME TO #{quote_schema_name(new_name)}"
+        end
+
         # Sets the schema search path to a string of comma-separated schema names.
         # Names beginning with $ have to be quoted (e.g. $user => '$user').
         # See: https://www.postgresql.org/docs/current/static/ddl-schemas.html

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1217,19 +1217,6 @@ module ActiveRecord
         collect_join_reflections(seed + [self])
       end
 
-      def deprecated?
-        unless defined?(@deprecated)
-          @deprecated =
-            if parent_reflection.is_a?(HasAndBelongsToManyReflection)
-              parent_reflection.deprecated?
-            else
-              delegate_reflection.deprecated?
-            end
-        end
-
-        @deprecated
-      end
-
       def deprecated_nested_reflections
         @deprecated_nested_reflections ||= collect_deprecated_nested_reflections
       end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1239,19 +1239,6 @@ module ActiveRecord
           source_reflection.actual_source_reflection
         end
 
-        def collect_deprecated_nested_reflections
-          result = []
-          [through_reflection, source_reflection].each do |reflection|
-            result << reflection if reflection.deprecated?
-            # Both the through and the source reflections could be through
-            # themselves. Nesting can go an arbitrary number of levels down.
-            if reflection.through_reflection?
-              result.concat(reflection.deprecated_nested_reflections)
-            end
-          end
-          result
-        end
-
       private
         attr_reader :delegate_reflection
 
@@ -1269,6 +1256,19 @@ module ActiveRecord
         def derive_class_name
           # get the class_name of the belongs_to association of the through reflection
           options[:source_type] || source_reflection.class_name
+        end
+
+        def collect_deprecated_nested_reflections
+          result = []
+          [through_reflection, source_reflection].each do |reflection|
+            result << reflection if reflection.deprecated?
+            # Both the through and the source reflections could be through
+            # themselves. Nesting can go an arbitrary number of levels down.
+            if reflection.through_reflection?
+              result.concat(reflection.deprecated_nested_reflections)
+            end
+          end
+          result
         end
 
         delegate_methods = AssociationReflection.public_instance_methods -

--- a/activerecord/lib/arel/crud.rb
+++ b/activerecord/lib/arel/crud.rb
@@ -21,6 +21,7 @@ module Arel # :nodoc: all
       um.offset(offset)
       um.order(*orders)
       um.wheres = constraints
+      um.comment(comment)
       um.key = key
 
       um.ast.groups = @ctx.groups
@@ -34,6 +35,7 @@ module Arel # :nodoc: all
       dm.offset(offset)
       dm.order(*orders)
       dm.wheres = constraints
+      dm.comment(comment)
       dm.key = key
       dm.ast.groups = @ctx.groups
       @ctx.havings.each { |h| dm.having(h) }

--- a/activerecord/lib/arel/delete_manager.rb
+++ b/activerecord/lib/arel/delete_manager.rb
@@ -28,5 +28,10 @@ module Arel # :nodoc: all
       @ast.havings << expr
       self
     end
+
+    def comment(value)
+      @ast.comment = value
+      self
+    end
   end
 end

--- a/activerecord/lib/arel/nodes/delete_statement.rb
+++ b/activerecord/lib/arel/nodes/delete_statement.rb
@@ -3,7 +3,7 @@
 module Arel # :nodoc: all
   module Nodes
     class DeleteStatement < Arel::Nodes::Node
-      attr_accessor :relation, :wheres, :groups, :havings, :orders, :limit, :offset, :key
+      attr_accessor :relation, :wheres, :groups, :havings, :orders, :limit, :offset, :comment, :key
 
       def initialize(relation = nil, wheres = [])
         super()
@@ -14,6 +14,7 @@ module Arel # :nodoc: all
         @orders = []
         @limit = nil
         @offset = nil
+        @comment = nil
         @key = nil
       end
 
@@ -24,7 +25,7 @@ module Arel # :nodoc: all
       end
 
       def hash
-        [self.class, @relation, @wheres, @orders, @limit, @offset, @key].hash
+        [self.class, @relation, @wheres, @orders, @limit, @offset, @comment, @key].hash
       end
 
       def eql?(other)
@@ -36,6 +37,7 @@ module Arel # :nodoc: all
           self.havings == other.havings &&
           self.limit == other.limit &&
           self.offset == other.offset &&
+          self.comment == other.comment &&
           self.key == other.key
       end
       alias :== :eql?

--- a/activerecord/lib/arel/nodes/update_statement.rb
+++ b/activerecord/lib/arel/nodes/update_statement.rb
@@ -3,7 +3,7 @@
 module Arel # :nodoc: all
   module Nodes
     class UpdateStatement < Arel::Nodes::Node
-      attr_accessor :relation, :wheres, :values, :groups, :havings, :orders, :limit, :offset, :key
+      attr_accessor :relation, :wheres, :values, :groups, :havings, :orders, :limit, :offset, :comment, :key
 
       def initialize(relation = nil)
         super()
@@ -15,6 +15,7 @@ module Arel # :nodoc: all
         @orders   = []
         @limit    = nil
         @offset   = nil
+        @comment  = nil
         @key      = nil
       end
 
@@ -25,7 +26,7 @@ module Arel # :nodoc: all
       end
 
       def hash
-        [@relation, @wheres, @values, @orders, @limit, @offset, @key].hash
+        [@relation, @wheres, @values, @orders, @limit, @offset, @comment, @key].hash
       end
 
       def eql?(other)
@@ -38,6 +39,7 @@ module Arel # :nodoc: all
           self.orders == other.orders &&
           self.limit == other.limit &&
           self.offset == other.offset &&
+          self.comment == other.comment &&
           self.key == other.key
       end
       alias :== :eql?

--- a/activerecord/lib/arel/select_manager.rb
+++ b/activerecord/lib/arel/select_manager.rb
@@ -255,8 +255,12 @@ module Arel # :nodoc: all
     end
 
     def comment(*values)
-      @ctx.comment = Nodes::Comment.new(values)
-      self
+      if values.any?
+        @ctx.comment = Nodes::Comment.new(values)
+        self
+      else
+        @ctx.comment
+      end
     end
 
     private

--- a/activerecord/lib/arel/update_manager.rb
+++ b/activerecord/lib/arel/update_manager.rb
@@ -45,5 +45,10 @@ module Arel # :nodoc: all
       @ast.havings << expr
       self
     end
+
+    def comment(value)
+      @ast.comment = value
+      self
+    end
   end
 end

--- a/activerecord/lib/arel/visitors/dot.rb
+++ b/activerecord/lib/arel/visitors/dot.rb
@@ -150,6 +150,7 @@ module Arel # :nodoc: all
           visit_edge o, "orders"
           visit_edge o, "limit"
           visit_edge o, "offset"
+          visit_edge o, "comment"
           visit_edge o, "key"
         end
 
@@ -159,6 +160,7 @@ module Arel # :nodoc: all
           visit_edge o, "orders"
           visit_edge o, "limit"
           visit_edge o, "offset"
+          visit_edge o, "comment"
           visit_edge o, "key"
         end
 

--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -29,6 +29,7 @@ module Arel # :nodoc: all
           collect_nodes_for o.wheres, collector, " WHERE ", " AND "
           collect_nodes_for o.orders, collector, " ORDER BY "
           maybe_visit o.limit, collector
+          maybe_visit o.comment, collector
         end
 
         # In the simple case, PostgreSQL allows us to place FROM or JOINs directly into the UPDATE

--- a/activerecord/lib/arel/visitors/sqlite.rb
+++ b/activerecord/lib/arel/visitors/sqlite.rb
@@ -29,6 +29,7 @@ module Arel # :nodoc: all
           collect_nodes_for o.wheres, collector, " WHERE ", " AND "
           collect_nodes_for o.orders, collector, " ORDER BY "
           maybe_visit o.limit, collector
+          maybe_visit o.comment, collector
         end
 
         def prepare_update_statement(o)

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -35,6 +35,7 @@ module Arel # :nodoc: all
           collect_nodes_for o.wheres, collector, " WHERE ", " AND "
           collect_nodes_for o.orders, collector, " ORDER BY "
           maybe_visit o.limit, collector
+          maybe_visit o.comment, collector
         end
 
         def visit_Arel_Nodes_UpdateStatement(o, collector)
@@ -48,6 +49,7 @@ module Arel # :nodoc: all
           collect_nodes_for o.wheres, collector, " WHERE ", " AND "
           collect_nodes_for o.orders, collector, " ORDER BY "
           maybe_visit o.limit, collector
+          maybe_visit o.comment, collector
         end
 
         def visit_Arel_Nodes_InsertStatement(o, collector)

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -201,6 +201,33 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
+  def test_rename_schema
+    @connection.create_schema("test_schema3")
+    @connection.rename_schema("test_schema3", "test_schema4")
+    assert_not_includes @connection.schema_names, "test_schema3"
+    assert_includes @connection.schema_names, "test_schema4"
+  ensure
+    @connection.drop_schema("test_schema3", if_exists: true)
+    @connection.drop_schema("test_schema4", if_exists: true)
+  end
+
+  def test_rename_schema_with_nonexisting_schema
+    assert_raises(ActiveRecord::StatementInvalid) do
+      @connection.rename_schema("idontexist", "neitherdoi")
+    end
+  end
+
+  def test_rename_schema_with_existing_target_name
+    @connection.create_schema("test_schema3")
+    @connection.create_schema("test_schema4")
+    assert_raises(ActiveRecord::StatementInvalid) do
+      @connection.rename_schema("test_schema3", "test_schema4")
+    end
+  ensure
+    @connection.drop_schema("test_schema3", if_exists: true)
+    @connection.drop_schema("test_schema4", if_exists: true)
+  end
+
   def test_raise_wrapped_exception_on_bad_prepare
     assert_raises(ActiveRecord::StatementInvalid) do
       @connection.exec_query "select * from developers where id = ?", "sql", [bind_param(1)]

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -375,6 +375,22 @@ module ActiveRecord
       end
     end
 
+    def test_relation_with_annotation_includes_comment_in_update_all_query
+      post_with_annotation = Post.annotate("foo")
+      all_count = Post.all.to_a.count
+      assert_queries_match(%r{/\* foo \*/}) do
+        assert_equal all_count, post_with_annotation.update_all(title: "Same title")
+      end
+    end
+
+    def test_relation_with_annotation_includes_comment_in_delete_all_query
+      post_with_annotation = Post.annotate("foo")
+      all_count = Post.all.to_a.count
+      assert_queries_match(%r{/\* foo \*/}) do
+        assert_equal all_count, post_with_annotation.delete_all
+      end
+    end
+
     def test_relation_without_annotation_does_not_include_an_empty_comment
       log = capture_sql do
         Post.where(id: 1).first

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -1013,7 +1013,7 @@ Previewing and Testing Mailers
 ------------------------------
 
 You can find detailed instructions on how to test your mailers in the [testing
-guide](testing.html#testing-your-mailers).
+guide](testing.html#testing-mailers).
 
 ### Previewing Emails
 

--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -129,7 +129,7 @@ $ sudo npm install --global yarn
 To install all run:
 
 ```bash
-$ sudo pacman -S sqlite mariadb libmariadbclient mariadb-clients postgresql postgresql-libs redis memcached imagemagick ffmpeg mupdf mupdf-tools poppler yarn libxml2 libvips poppler
+$ sudo pacman -S sqlite mariadb libmariadbclient mariadb-clients postgresql postgresql-libs redis memcached imagemagick ffmpeg mupdf mupdf-tools poppler yarn libxml2 libvips
 $ sudo mariadb-install-db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
 $ sudo systemctl start redis mariadb memcached
 ```


### PR DESCRIPTION
- **Avoid running console tests against users IRB config**
- **Update engines.md**
- **Add tools/cve_announcement.rb**
- **Add `reply_to_address` Mail extension**
- **docs: use `db:seed:replant` for resetting seed data**
- **Add canonical link tag to guides head**
- **Update Getting Started guide for Rails 8 Also introduces Install Ruby on Rails guide**
- **Add database reset suggestion [ci-skip]**
- **Change `ActionText::RichText#embeds` assignment to `before_validation`**
- **Fix linter issues**
- **Apply suggestions from code review**
- **Add Dev Container to Install guide Also updates Dev Container guide to reference the Store application.**
- **Use range for highlighting lines**
- **Fixed the auto-scrolling issue of the column-side element in the desktop version**
- **Apply suggestions from code review**
- **Run reload! in console after adding validation**
- **Clarify a few sections**
- **Apply suggestions from code review**
- **Use bin/rails consistently**
- **Apply suggestions from code review**
- **Move production guides to separate section [ci-skip]**
- **Conistently release the autoloading interlock from all adapters**
- **Use default function as default insert value when present**
- **Refactor Active Record Adapter#handle_warnings**
- **Support <picture> element in guides**
- **Apply suggestions from code review**
- **Changing column null does not change default function**
- **Fix lazy attribute method definitiont to be thread safe**
- **Action Cable pg adapter: avoid using a pinned connection**
- **Add an example for AR.db_warnings_ignore [ci skip]**
- **Revert "Support <picture> element in guides"**
- **Adding diagrams in getting started**
- **code highlighting for .hll (new lines added)**
- **[RF-DOCS] Document Rails 8 Authentication generator feature [ci-skip] (#53802)**
- **a bit of spacing on the highlight border callout**
- **Add more code highlights and make a few things more consistent**
- **Add path to version select in guides**
- **80 character line limit**
- **Add styles for product show page**
- **Explain local variables for partials**
- **Update text**
- **Adjust to 80 chars**
- **Fix typo**
- **Use assert_in_delta to fix timestamp failure**
- **Relax assert_in_delta since MySQL's timestamp has no precision by default**
- **Fix canonical_url in guides**
- **Skip tests if adapter does not support insert_all/upsert_all**
- **Add CSP directive validation**
- **Update vendored trix version to 2.1.10**
- **Mysql2Adapter: gracefully handle `Unknown prepared statement handler` errors**
- **Migrate `ActiveRecord::Normalization` to Active Model**
- **Fix typo in autoloading guide [ci skip]**
- **Update version to 8.1 in the getting started guide**
- **Update homebrew path**
- **Update nokogiri to fix CI crashes**
- **Add an option to ensure uniqueness of newly generated session IDs in `Session::CacheStore`**
- **Revert "Merge pull request #53814 from yahonda/skip_minitest_5253"**
- **Fix nested tests in `insert_all_test.rb`**
- **Enable Lint/NestedMethodDefinition cop**
- **Fix returning docs for upsert_all [ci skip]**
- **[RF-DOCS] Remove stray closing tag in Rails 8 Authentication generator code snippet [ci-skip]**
- **Fix removing foreign keys with `:restrict` action for MySQL**
- **Use single query to retrieve indexes in PostgreSQL**
- **Fix rdoc link to `SchemaStatements#add_check_constraint`**
- **Use Rack's SERVER_PROTOCOL instead of HTTP_VERSION header**
- **Merge pull request #53926 from Ridhwana/Ridhwana/solid-queue**
- **[RF-DOCS] Solid Cache updates in Caching with Rails: An Overview [ci-skip]  (#53939)**
- **[RF-DOCS] Asset Pipeline Documentation (Propshaft) [ci-skip] (#53875)**
- **railties/test_parser: Cache work done in definition_for.**
- **[RF-DOCS] Update Rails Testing Guide [ci skip] (#53872)**
- **Remove N+1 due to column name resolution in PG adapter methods**
- ** ActiveModel::Attribute: elide dup for immutable types**
- **Remove monkey patches of Range#each and Range#step**
- **Convert `[]` in heading to `-squarebrackets` in id**
- **fixup! Remove N+1 due to column name resolution in PG adapter methods**
- **Add dot suffix to headings in guides**
- **Allow to tag serialized attributes as comparable**
- **Fix copy in activerecord CHANGELOG**
- **Do not validate associated records that haven't changed**
- **Fix rdoc code render in `ActionCable::Connection::TestCase` docs**
- **[ActiveJob docs] fix development database configuration yml example**
- **Revert "Migrate `ActiveRecord::Normalization` to Active Model"**
- **Handle nested middle belongs_to, not-loaded target when setting through records**
- **Handle cyclic template dependencies**
- **Handle new records in `#increment!`**
- **Fix `#to_query` to not include `=` for nil values**
- **Set secret_key_base to avoid generation of temp files**
- **Set the queue adapter to :test in the bug report template**
- **Rewrite confusing code for getting association class**
- **Remove note about nested locale folders configuration**
- **Fix example in `ActionController::Caching` docs**
- **Deprecate `ActiveSupport::Configurable`**
- **Don't cache `module_parent_name` on anonymous modules**
- **Fix yarn installation method for yarn > 1.x.x**
- **ErrorSubscriber: also marks the error causes as reported**
- **Remove redundant codes in section 16.4 of  getting_started.md**
- **Fix `ActionDispatch::Executor` to unwrap exceptions like other middlewares**
- **Update association_basics.md**
- **Fix class inheritance**
- **Ensure relation is loaded before mutation [ci-skip]**
- **Use `limit` in `#sole`, not `first`.**
- **Fix `sum` with qualified name on loaded relation**
- **Updated Arel spec tests to check for assertionless tests**
- **Extract --skip docs into section**
- **Fix count with group by qualified name on loaded relation**
- **Include test env in description of .unexpected**
- **Prevent Active Storage Blob from autosaving Attachments:**
- **Fix rdoc code render in `Rails::CodeStatistics` docs**
- **Fix #54009 getting_started.md doc**
- **Update guides/source/getting_started.md**
- **Introduce versions formatter for the schema dumper**
- **Fix the rails new -A description**
- **Remove unused requires and refactor teardown**
- **Fix example should use class method instead of DatabaseStatements#transaction [ci skip]**
- **Default to the `host` config for db connection for trilogy adapter**
- **Update required version comment for MySQL**
- **Handle path_params gracefully when a user sends ?path_params=string**
- **Support plaintext bun lockfile**
- **Fix typo on getting_started.md**
- **Fix a few typos on the new Getting Started tutorial**
- **Fix missing hyperlink on new Getting Started tutorial**
- **Fix reference to view file in getting-started tutorial**
- **Ensure rdoc picks up Hash#deep_merge! [ci skip]**
- **Fix belong_to typo in Active Record Associations guide**
- **Remove redundant `quiet` check**
- **Fix formatting of code example [ci-skip]**
- **Use appropriate monospace style [ci-skip]**
- **Autolink Enumerable::SoleItemExpectedError [ci-skip]**
- **Clarify `indentation` and `with_indentation` docs [ci-skip]**
- **Link to ActiveSupport::TimeZone.utc_to_local API doc [ci-skip]**
- **Use actual descriptions for link text [ci-skip]**
- **Use autolink instead of explicit link [ci-skip]**
- **Remove superfluous "or not" [ci-skip]**
- **Link javascript_include_tag and stylesheet_link_tag [ci-skip]**
- **Use `delete_prefix` in `add_filter` example [ci-skip]**
- **Tweak `raise_on_invalid_cache_expiration_time` doc [ci-skip]**
- **Use monospace formatting [ci-skip]**
- **Handle polymorphic collection associations when setting through records**
- **[issue-54044] fixed small type let' -> let's in getting_started guide**
- **[rail_inspector] Use Prism for Visitor::Attribute**
- **Fix typo in initialization.md**
- **[rail_inspector] Prism for Visitor::HashToString**
- **[rail_inspector] Prism Visitor::FrameworkDefault**
- **Check if pinned connection is still available before checking it out**
- **Fix two unused block warnings on Ruby 3.4**
- **Fix `config.active_record.schema_versions_formatter` example [skip ci]**
- **Fix retrieving PostgreSQL indexes with keyword-named columns**
- **Add missing whitespace to Generating Child Models section**
- **Update outdated link to main branch in documentation**
- **[ci-skip][doc] Fix typo in Validation Guides**
- **Correct example ActiveStorage fixture file path**
- **Use released version of `websocket-client-simple`**
- **Docs: of -> on [ci-skip]**
- **Fixes minor typo in the controller overview guide**
- **typo: min_thread to min_threads in config.active_record.async_query_executor docs**
- **Fix `String#mb_chars` to never mutate the original String**
- **Fix inverting `drop_table` without options**
- **fix: support proc symbol on callbacks conditionals, fixes: #54056 issue**
- **Document AS::Cache#write unless_exist option**
- **Colorize console prompt on non standard environments**
- **Clean up and improve various notification asserting tests**
- **Update devcontainer to use ruby version 3.4.1**
- **Round rails logo**
- **[ci-skip][docs] Update link to register_parser**
- **[ci-skip][docs] Fix sample for `:allow_blank`**
- **Removed unsupported choice options from comment**
- **Fix running individual app:update commands**
- **Remove TrilogyAdapterTest custom notification assertion helpers**
- **Fix some parts of the Solid Queue documentation**
- **Fix typo in testing guide**
- **Remove links to older guide versions from index page.**
- **Fix typo in ActiveSupport::Cache::Store docs**
- **Show db:migrate:reset in `rake --tasks`**
- **Don't eagerly compile StringJoin nodes**
- **Add config option for MD5 class**
- **Capitalize subject in a Getting Started guide heading [ci-skip]**
- **Add missing api docs link and remove embedded url versions**
- **Fix DATABASE_URL variable in the ci template [skip ci]**
- **Strip extra space in the version variant**
- **[ci skip] Configure encryption in `active_record` bug report template**
- **Fix guides url does not work when clicking the link [ci skip]**
- **fix: ArgumentErrors raised during template rendering**
- **ActionView: Layouts can access local variables**
- **Use constant instead of comment in MySQL2Adapter**
- **Migrate `ActiveRecord::Normalization` to Active Model**
- **"encryption,database" => "encryption, database" [ci skip]**
- **Fix NameError: uninitialized constant ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements::ER_UNKNOWN_STMT_HANDLER**
- **Sort table columns by name when dumping schema**
- **Load configured Active Storage plugins during boot**
- **Use assert_raises(match:) for lock_version: nil tests**
- **docs: Update all code snippets to the latest version [ci skip] (#54118)**
- **[ci skip] change "Destroy" to "Delete" on button for consistency**
- **Fix name of the gem being required**
- **CI: Introduce `RAILS_MASTER_KEY` placeholder**
- **Add test case to demonstrate Thread.current locals are cleared in the test environment**
- **Fix boolean columns triggering MySQL deprecation**
- **Patch ActionController:Live in the test environment to prevent clearing thread locals as the new_controller_thread actually yields the current thread**
- **Don't load ActiveStorage::Blob when validating the service**
- **Use `form` in `html_options` for `collection_check_boxes`**
- **Deprecate `String#mb_chars` and `AS::Multibyte::Chars`.**
- **Avoid triggering AS::Multibyte deprecation when quoting**
- **Align example URL with protocol explanation**
- **Fix: ensure pg enums with commas are dumped correctly**
- **Fix small typo on Railties CHANGELOG and comment**
- **Add a space between words in Getting Started docs**
- **Add resource name to the `ArgumentError` that's raised when invalid `:only` or `:except` options are given to `#resource` or `#resources`**
- **Update assert_notification: payload subset matching, notification return**
- **Fix MiniMagic::Image.mime_type deprecation in ASto test**
- **Fixed typo in the  article "2.6.1.4 Building and Creating Associated Objects"**
- **Railties sprockets_assets_test use URI::RFC2396_PARSER instead of DEFAULT_PARSER**
- **Ensure that `ActiveStorage.analyzers` doesn't contain nil**
- **Fix assert_no_file with unused block warning**
- **Fix RuboCop offense in benchmark generator template**
- **Suggest to use bin/rails runner in commands help**
- **Fix benchmark_generator_test**
- **Delegate `ActiveStorage::Filename#to_str` to `#to_s`**
- **Fix Railties Tests**
- **Eliminate allocations on Model.respond_to? calls**
- **Fix inserts on MySQL with no `RETURNING` support for a table with multiple auto populated columns**
- **Fix load_active_support initializer doc**
- **Make RequestForgeryProtection::NULL_ORIGIN_MESSAGE private**
- **Make FilterParameters#ENV_MATCH, NULL_ENV_FILTER, NULL_PARAM_FILTER nodoc**
- **Fix ActionDurationCallback.around**
- **Don't dup query values if they're frozen**
- **Add `railspect requires` for auditing `require`s**
- **Test disabled session in blobs and representation proxy controllers**
- **`./tools/railspect requires . -a` + manual fixes**
- **Add deprecations to 8.0 Release Notes**
- **Really make sure AS::Deprecation::Reporting constants are private**
- **Replace Forwardable with ActiveSupport::Delegation**
- **Remove extra new lines in the generated Gemfile**
- **Cleanup ActiveSupport::JSON**
- **Flash.add_flash_types should define helpers as private**
- **Fix ActionDispatch::Request::HTTP_METHOD_LOOKUP being impacted by inflections from gems**
- **Authentication generator controller clears browser cache at logout**
- **Fix inconsistency between `delete_all` & `update_all` allowed methods:**
- **Fix typo in routing guide**
- **Fix incorrect expiration time in ActiveSupport::Cache::Store#fetch**
- **Fix default docker build.**
- **Upgrade docker smoke tests to use Ruby 3.4**
- **Fix typo in `active_storage_overview.md` guide**
- **Skip persisted through targets when autosaving collection associations**
- **Fix usable values for openssl_verify_mode configuration in Action Mailer Guide**
- **Enable `#exists?` queries to be retryable**
- **Update nokogiri to fix Devcontainer smoke test**
- **Fix an incorrect example in the doc of the Strong Parameters [ci skip]**
- **Update Gemfile.lock to fix Devcontainer smoke test**
- **Add direct insert and direct delete methods to a guide [skip ci]**
- **Don't include `script` and `style` content to node plaintext conversion**
- **Ensure binding is always `0.0.0.0`.**
- **guides/source/caching_with_rails.md: remove dup**
- **Lock RDoc to 6.9 until sdoc is fixed**
- **Remove redundant "Filtering" comment [ci skip]**
- **Reduce the frequency of Dependabot updates in new projects.**
- **Handle missing attributes for AM::Translation#human_attribute_name**
- **Revert "Skip persisted through targets when autosaving collection associations"**
- **Revert "Handle polymorphic collection associations when setting through records"**
- **Revert "Handle nested middle belongs_to, not-loaded target when setting through records"**
- **Revert "Handle setting of nested through records for new records"**
- **Revert "[Fix #33155] Set through target for new records"**
- **Remove stale documentation about `assets.debug`**
- **Freeze database conversion types**
- **Make payload[:name] of eager loading `sql.active_record` to "#{model.name} Eager Load".**
- **Add regression test for has_many_through associations failing to create join models**
- **Remove deprecated calls to String#mb_chars in ActiveRecord**
- **Update link to Getting Started guide in Testing Rails guide [ci skip]**
- **Use `secret_key_base` from ENV or credentials when present locally**
- **Load schema for Author table in test**
- **Add `application-name` metadata to application layout**
- **Remove warning silence on Journey::Parser require**
- **Add a script for using dev containers outside VSCode**
- **Refine step in the Sprockets to Propshaft migration guide**
- **Doc: Format CSRF argument lists**
- **Format `fill_in_rich_textarea` API docs correctly**
- **Move back to kwargs for (de)increment for cache stores**
- **Improve deprecation of String#mb_chars**
- **Add instructions to set up the testing database in plugin documentation**
- **Update tools/devcontainer**
- **Remove unnecessary executable bit form docker-entrypoint.tt**
- **Make column name optional for `index_exists?`**
- **Prevent persisting invalid record:**
- **Doc: Using assert_select in guide of testing**
- **Deprecate using insert_all/upsert_all with unpersisted records in associations.**
- **JSON serialized attributes can return symbolized keys - `ActiveRecord::Coder::JSON` can be instantiated with options - `ActiveSupport::JSON` now accepts options**
- **docs: rails debug guide - add detail on verbose logs [ci-skip]**
- **Will not cause `insert_all` to error [ci-skip]**
- **Update `has_one` example to use descending order [ci skip]**
- **Use already-loaded relation contents in #sole**
- **Fix routes being cleared when using `reload_routes!`:**
- **AS::MessageVerifier#verify always accept both safe and unsafe encoding**
- **Prefer assert_dom over assert_select.**
- **Improve test_json_symbolize_names_returns_symbolized_names**
- **refactor(test): do not dump when not necessary**
- **Fix `serialize coder: JSON, type: Hash` to wrap the coder in `ColumnSerializer`**
- **Use bash code fences for install guide [ci skip]**
- **Added documentation for rails db:system:change command**
- **Moved the documentation to ./bin/rails db: section**
- **Update environment name to development**
- **Improve test coverage for ErrorReporter**
- **Raise an ArgumentError when Rails.error.report is passed something that is not an Exception**
- **Do not raise when Rails.error.report receives context: nil**
- **Allow passing in a date or time to ActiveSupport::Testing::TimeHelpers#freeze_time**
- **Ensure type map queries are counted by assert_queries_count**
- **Extend --minimal option**
- **Reset Deduplicable singleton caches in schema cache tests**
- **Eliminate queries loading dumped model schema on Postgres**
- **ActiveSupport::ErrorReporter#report does not accept String argument**
- **[ci skip]docs: Fix typo in guide**
- **[ci skip] Add a mention to `db:create` in the getting started guide:**
- **Improve wording in getting_started.md guide [skip ci]**
- **Fix active record instrumentation not thread safe:**
- **Make the schema cache forward compatible with the changes in Column**
- **Add names to all `Concurrent::ThreadPoolExecutor`s**
- **Suggest to run rails command under bin/ in comment**
- **Add a missing `assert_deprecated` in quoting_test.rb**
- **Fix column_definition returning a wrong column:**
- **Fix `rotate(on_on_rotation:)` and `#on_rotation`**
- **[ci skip] Clarify the doc for creating links:**
- **Accept on_rotation argument in find_signed**
- **PoolConfig no longer keeps a reference to the connection class.**
- **Remove `rotate(on_rotation:)` argument**
- **Make the devcontainer script work with podman**
- **Load the routes when starting a console:**
- **Avoid checking if internal objects respond to methods**
- **Remove node_modules from the final image when using bun**
- **Fix two unused block warnings in arel**
- **Use anonymous block to ignore unused block warnings**
- **Revert "Merge pull request #54230 from flavorjones/flavorjones-clear-site-data-on-logout"**
- **Update vendored Trix version to 2.1.12 (#54099)**
- **Fix Dockerfile comments for bun**
- **Skip inflector when generating HTTP_METHOD_LOOKUP**
- **[ci skip]Fix the sample code about Null Relation**
- **Fix inverting `rename_enum_value` when `:from`/`:to` are provided**
- **Clear AR connections in tests before forking for parallelization**
- **A typo that slipped in from #54376**
- **Move to GitHubs new issue templates**
- **Update asset_pipeline.md**
- **Inline `IsolatedExecutionState#state`**
- **Add missing `require` in ImageMagick analyzer**
- **Pad a space after screenshot image path or html url for clickability**
- **LocalCache with read_multi should respect version and expire**
- **Avoid crash to validate circular autosave association**
- **Run tests with `--profile` on CI**
- **No dump of the entire template when a syntax error is encountered:**
- **docs: enhance assert_changes and assert_no_changes documentation**
- **Explicitly call I18n.exception_handler on missing translation**
- **Avoid autolinking FormHelper#fields_for to itself [ci-skip]**
- **Avoid autolinking FormHelper#form_for to itself [ci-skip]**
- **Autolink FormHelper#form_with [ci-skip]**
- **Autolink FormHelper#form_for [ci-skip]**
- **Autolink FormTagHelper#checkbox_tag [ci-skip]**
- **Remove RDoc syntax in code example comments [ci-skip]**
- **Autolink UncacheableFragmentError [ci-skip]**
- **Autolink FormBuilder#form_with [ci-skip]**
- **Avoid autolinking FormBuilder#fields_for to itself [ci-skip]**
- **Autolink FormBuilder#fields_for [ci-skip]**
- **Autolink FormBuilder#text_field [ci-skip]**
- **Use method call syntax in delegated_type examples [ci-skip]**
- **Use monospace formatting [ci-skip]**
- **Correct generated id values in fixture docs**
- **Collect test results and print profile summary at the end**
- **speed up docker build**
- **Workaround for `cannot load such file -- net/smtp (LoadError)`**
- **Further restrict which contradicted queries need to be run**
- **Defer creating the Active Model attribute-method module**
- **Fix `Enumerable#sole` for infinite collections**
- **Make internal query() retryable for postgresql**
- **Fix NoMethodError when a non-string CSRF token is passed through header**
- **Reorder conditions in HashWithIndifferentAccess#initialize**
- **Avoid unecessary hash allocation in AttributeMutationTracker#changes**
- **Handle connection pool errors in Redis and Memcached stores**
- **Rate limit password resets in auth generator**
- **Add HashWithIndifferentAccess#raw_store**
- **Support joins in `update_all` for Postgresql and SQlite**
- **Skip test if upsert/insert-duplicate not supported by database adapter**
- **[docs] Use 'raises' to describe behaviour in CollectionProxy#find**
- **Go back to released version of net-smtp**
- **Update webmock to fix net-http deprecation warning**
- **Fix example :blank error message in i18n to match default error [ci skip]**
- **Fix ActionCable allowed_request_origin configuration guide typo**
- **Small tweaks to `sql.active_record` guide**
- **Add `allow_retry` to `sql.active_record`**
- **Enable statement-cached queries to be retryable**
- **Fix migrating multiple DBs with pending migration action**
- **Reword changelog**
- **Enable query-cacheable queries to be retryable**
- **Fix SqlLiterals overriding query's retryable value**
- **Handle ConnectionPool::TimeoutError in Redis and Memcached stores ConnectionPool::TimeoutError does not inherit from ConnectionPool::Error ref: rails#54432 and rails##54440**
- **Speedup cache store pool timeout tests**
- **Regex escape table names and quoted table names used in regex**
- **Allow execution wrapper to handle all exceptions**
- **Update routing.md**
- **Improve CHANGELOG**
- **Pass keyword arguments to PostgreSQL Adapter Table methods**
- **Add missing space separator when there are multiple JOINS**
- **Simplify stdparam state to reduce retained hashes**
- **Fix JSON test leaking constants**
- **Skip allocation when JSON options are nil**
- **Allow other database adapters in tests**
- **Use JSON::Coder when available**
- **Link Rails.application.key_generator [ci-skip]**
- **Autolink ActiveSupport::MessageVerifier [ci-skip]**
- **Avoid undefined String#squish in Rails::TestUnit**
- **Make ActiveModel::Type::Value mutable? default to true, so custom/user types are still mutable. Added a nodoc Helpers::Immutable for internal types**
- **Fix unreadable output when running `rails test`:**
- **Speed up GTG Simulator by reducing slices/matches**
- **Fix sqlite3 dbconsole not working outside Rails**
- **[docs] Use 'valid' instead of 'legal' for cache key**
- **Optimize JSON escaping**
- **Flatten the transition table state arrays**
- **Replace `each_slice` by a `while` loop**
- **Allow JSON::Fragment as a return value for as_json**
- **Support JSON::Fragment with the old JSON encoder**
- **Fix typo in Rails routing guide**
- **Optimize String visitor by hand**
- **Stop eagerly computing `request.route_uri_pattern`**
- **Improve Fragment handling in JSON::Encoding**
- **Cache Journey Node#to_s**
- **Micro-optimize Router#find_routes**
- **Get rid of Jounry::Utils.unescape**
- **Micro-optimize Journey normalize_path**
- **Micro optimize route sorting in Router find_routes**
- **Skip get_header and set_header for hot methods on Request**
- **Fix RDoc for ActionView::TestCase::Behavior#rendered**
- **Fix on_rotation for find_signed! & find_signed**
- **[ci skip] Tweak the Action Mailer callbacks documentation:**
- **Add MessageVerifiers#rotate block form signature [ci-skip]**
- **Use ::new instead of #initialize for ghost methods [ci-skip]**
- **Add {MessageEncryptors,MessageVerifiers}#prepend**
- **Avoid `#any?` since `via` is usually singular**
- **Check constraints exist before call `#any?`**
- **Iterate custom_routes instead of allocating**
- **Only iterate path_parameters once**
- **Construct path_parameters from merged hash**
- **Reorder equality so happy path hits `Nil#==`**
- **Update Saucelabs configuration**
- **Only generate an UPDATE/FROM if the first join is an INNER JOIN**
- **Use adapter support flags instead of checking adapter type**
- **Align postgresql server/client versions mismatch when using devcontainer**
- **Use `Minitest#flunk` instead of raising an Assertion error:**
- **Add `report:` option to `ActiveJob::Base#retry_on` and `#discard_on`**
- **Remove accidentally committed profile**
- **Improve issue template formatting [skip ci]**
- **Fix generating `database.yml` when skipping Kamal**
- **Fix SafeBuffer#as_json**
- **Fix arity of SafeBuffer#as_json**
- **Fix `update_all` producing a broken query:**
- **Modify `update_all` to use a sub select query in some cases:**
- **Address `.devcontainer/boot.sh: 3: [[: not found`**
- **doc: Explicitly state that modifying sanitizer allowlists is unsafe**
- **[ci skip] Modify all remaining references of `rails <command>`:**
- **Make .devcontainer/boot.sh pass shellcheck**
- **Add Timezone America/Asuncion**
- **Fix `#recognize` inconsistency with `#serve`**
- **docs: add podman instructions for devcontainers [ci skip]**
- **Partial revert of #54569**
- **Fix leaky test:**
- **add note of query_log_tags_enabled**
- **Fix test when Rails may not be defined:**
- **[Fix #53758] Raise `ActiveRecord::ReadOnlyError` when pessimistically locking with a readonly role**
- **Destroy all sessions on password reset (#54524)**
- **Do cheap/happy check first in `verified_request?`**
- **Add SafeBuffer to the list of messagepack serializable type:**
- **Fix LocalStore#read_multi_entries to distinguish recorded misses**
- **Deserialize column defaults**
- **Use released version of httpclient**
- **Add column types to `ActiveRecord::Result` for SQLite3**
- **Lazily build `ActiveRecord::Result#column_types`**
- **[Guides] removed routing_filter gem reference as it is outdated [ci-skip]**
- **Show line numbers in Rails console**
- **Ensure `#reverse_order` respects `implicit_order_column`**
- **Support disabling indexes for MySQL and MariaDB**
- **Make lint optional, so we can pass invalid host name.**
- **Use `mariadb:lts` at Dev Container**
- **Update devcontainer to use ruby version 3.4.2**
- **Move StrictWarnings to the tools directory**
- **Inline find_routes into recognize**
- **[ci skip] Fix incorrect backticks in getting-started docs**
- **Only create one config per AV::Base**
- **Upgrade RedCarpet to fix a Ruby deprecation warning**
- **Locks rubocop in Gemfile**
- **Introduce ErrorReporter context middleware**
- **Ensure that `after_generate_callbacks` are looked up through accessor**
- **Improve ActiveSupport::JSON.encode documentation**
- **Add login_as(user) testing helper when generating authentication (#53708)**
- **Use `#report` parameters in error context middleware**
- **Fix async aggregation queries to return promise for contradicted queries**
- **Enable `Minitest/AssertNil` cop to address `DEPRECATED: Use assert_nil if expecting nil` warning**
- **Modify the Test Runner to allow running test at root:**
- **Create PostgreSQL and MySQL databases at devcontainer**
- **Document pluralize_table_names limitation with Rails generators/installers**
- **Bump selenium-webdriver to 4.29.1**
- **Note added for rails command in rails guide doc [ci skip] (#54461)**
- **Fix CurrentAttributes not setting an attribute's default:**
- **Fix: ActiveJob::Exceptions.discard_on report option should default to false to preserve existing behaviour.**
- **Support hash options for YJIT configuration**
- **Add db:migrate to 8.0 Release Note Notable Changes**
- **Fix creating fsm visualizer with lazy routes**
- **docs: clarify async adapter limitation**
- **Remove redundant package install for shellcheck**
- **Tweak the ActiveRecord callbacks doc Added details of transaction callbacks**
- **Use RuboCop plugin**
- **Add a config for auto-including nonce (#53835)**
- **Add PasswordsController tests for the authentication generator (#53255)**
- **Add anchor links to FormOptionsHelper [ci skip]**
- **Don't deserialize mutable defaults**
- **Optimize `String#parameterize`**
- **docs: fix punctuation**
- **docs: fix punctuation**
- **Fix channel generator import statement:**
- **RuboCop: target the current Ruby version rather than old 2.7 (#54692)**
- **Revert "RuboCop: target the current Ruby version rather than old 2.7 (#54692)"**
- **Stop generating bundler binstub:**
- **Fix capture view helper to pass keyword arguments**
- **Enable `MYSQL_CODESPACES` environment variable in the devcontainer**
- **Add `except_on:` option for validation callbacks**
- **Move test helpers into test_helpers (#54688)**
- **Allow per-database schema format in database config**
- **Raise `DoubleRenderError` on `head` after rendering**
- **[ci skip]Fix the incorrect version where `allow_browser` was added in the guide**
- **Cleanup #53666**
- **Fix `ActiveRecord::Result#dup` consistency**
- **Remove used ActiveRecord::Result method**
- **Add a default bin/bundle-audit configuration (#54695)**
- **Fix `ActionMailer::Base.default` docs [skip-ci]**
- **Ensure CI files are valid YAML**
- **Don't waste time installing packages that are already present**
- **Use dedicated GitHub Action jobs for tests and system tests**
- **perf: prevent unnecesary query on schema_search**
- **Don't rebuild the middleware stack when using `with_routing`:**
- **[ci skip] Fix form_with model binding example in guides**
- **Expose ability to prepend query log tags via application configuration**
- **Fixes perf improvement breaking ActionController::TestCase**
- **Fix typo in Active Job Basics guide**
- **Disconnect if `configure_connection` failed**
- **activerecord: Don't always append primary keys etc. to order conditions**
- **Generate session controller tests for auth generator (#53726)**
- **Update bundler-audit.tt to reference config/bundler-audit.yml (extension is `.yml` instead of `.yaml`)**
- **Handle libpq db version 0 as connection failure in `PostgreSQLAdapter`**
- **Structured CI with bin/ci (#54693)**
- **Don't rely on `which` for testing ContinuousIntegration**
- **Get rid of useless `:itself` proc**
- **Left-over from earlier design**
- **File has to be valid YML**
- **[hotfix/guides/active-record/validations/insert-and-upsert-api-links-moved]**
- **Implement respond_to_missing? for ActiveRecord::Migration**
- **Add additional platforms for gems with native extensions**
- **Add inspect to ActiveStorage::Service, ActiveStorage::Service::Registry, and ActiveStorage::Service::Configurator**
- **Handle `PG::ConnectionBad` from `PG#server_version` similarly to version 0**
- **Bump bundler inside the devcontainer**
- **docs: add SolidCable adapter configuration steps**
- **Update PostgreSQL UUID documentation [ci-skip]**
- **Make importmap changes invalidate HTML etags by default (#54021)**
- **Generate mailer files in auth generator only if ActionMailer is used**
- **Revert "Modify the Test Runner to allow running test at root:"**
- **fix: sqlite3 adapter quotes Infinity and NaN**
- **Fix AuthenticationGeneratorTest**
- **AbstractAdapter#attempt_configure_connection: handle Timeout.timeout**
- **Fix typo in Action Controller Advanced Topics guide**
- **Update json gem**
- **Let minitest parse ARGV:**
- **Split `bin/rails test test:system` into two steps:**
- **Fix regression in ActiveRecord::Result#column_types**
- **Remove method_added hook doing nothing:**
- **Add tests**
- **Skip one allocation when there are no JSON options**
- **Add `escape: false` option to `ActiveSupport::JSON.encode`**
- **Skip JSON escaping when writing into JSON columns**
- **Add RuboCop cache to GHA workflow templates**
- **Convert ActionCable CoffeeScript example to JavaScript**
- **Load lazy route set before inserting test routes**
- **Fixed type in form_helpers.md**
- **Test if `insert_all` / `upsert_all` apply correct values**
- **Support UPDATE outer joins on PostgreSQL and SQLite with a self-join transform**
- **Add rollup-plugin-terser as a dev dependency:**
- **Bump rubocop-packaging to 0.6.0**
- **Address MultibyteCharsExtrasTest#test_should_compute_grapheme_length failure with Ruby 3.5.0dev**
- **[ci-skip] Rails Guides: PostgreSQL timestamp with time zone**
- **Read generator options properly**
- **Introduce ActiveSupport::Testing::ErrorReporterAssertions#capture_error_reports**
- **Add a test for the email normalization**
- **Fix the indentation and whitespaces in the PasswordsController**
- **Add :variant option to Partial Rendering**
- **Don't always escape JSON when calling render json:**
- **Add a config.action_controller.json_renderer_escapes framework default**
- **Fix #54805.**
- **Enable join table references to stay retryable**
- **Ensure function aliases allow retrying queries**
- **Fix typo in Action Controller Overview guide**
- **Add `must-understand` directive according**
- **Verify `script/` directory creation in api app generator test #52335**
- **Include cookie name in length calculation**
- **Extract system test setup to system_helper**
- **Generate deploy config without extra blank lines**
- **[ci skip] docs(activestorage): Update default variant processor**
- **misc: fix spelling in Markdown and Ruby files**
- **Add `Cache#read_counter` and `Cache#write_counter`**
- **Use status code 303 for redirect in destroy action**
- **[ActiveRecord] Introduce with_default_isolation_level**
- **Add `default_isolation_level` on `NullPool`**
- **Fixed-width == and === docs do not work with RDoc short-hand**
- **Fix typo in The Rails Command Line guide**
- **ActiveSupport::Cache::RedisCacheStore use UNLINK instead of DEL**
- **Add missing test case for default_isolation_level**
- **Copy Active Storage test fixture racecar.jpg into Railties fixtures**
- **Update routing.md**
- **Added tests for verifying content length presence in response headers**
- **Document configuring non-primary db with env var**
- **Isolate AS::Message{Encryptor,Verifier} rotations on dup**
- **Use Rails.application.message_verifiers for signed IDs**
- **Add support for filtering notes by tag in /rails/info/notes**
- **Move AbstractAdapter#valid_type? to a class method**
- **Fix `create_or_find_by` not rolling back a transaction:**
- **[Fix #50256] stale state for composite foreign keys in belongs_to association**
- **Encryption: allow turning on `support_unencrypted_data` at a per-attribute level (#51100)**
- **Clean backtrace from Active Job perform exceptions**
- **Allow allocated Active Records to lookup associations**
- **Fix typo in Tuning Performance for Deployment guide**
- **Fix missing autoload for ActionView::StrictLocalsError**
- **Fix `polymorphic_url` and `polymorphic_path`:**
- **Bump minimum supported SQLite to 3.23.0**
- **Add ActiveRecord::Base.establish_connection behavior change to Rails 7.2 release notes.**
- **Add changelog for #54907 [ci skip]**
- **Use `TRUE` and `FALSE` for booleans in SQLite**
- **Bring back the period in checking database version message**
- **Update active_storage_overview.md**
- **exceptions_app is called with safe format**
- **Fix `find_or_create_by!` not checking owner persistence:**
- **Fix configuring `RedisCacheStore` with `raw: true`**
- **Improve leap years counting performance in distance_of_time_in_words**
- **Fix instance variable name typo**
- **Allow to configure maximum cache key sizes**
- **Use MySQL instead of MariaDB in devcontainer**
- **Clarify Active Storage setup for importmap-rails**
- **Update devcontainer to use ruby version 3.4.3**
- **Action Cable: Allow setting nil as subscription connection identifier for Redis**
- **Fix dropdown not opening - Removes *potentially* unnecessary js from the code - Closes a div in the index file**
- **Don't recalculate GROUP BY in {update,delete}_all**
- **Don't recalculate HAVING in {update,delete}_all**
- **Pass existing connection to #arel in #to_sql**
- **Add assert_in_body/assert_not_in_body (#54938)**
- **Ensure all railties tests require strict_warnings**
- **Assume some warnings might not have the full PROJECT_ROOT**
- **Add --reset option to bin/setup (#54952)**
- **Fix broken weblog.rubyonrails.org links in Guides [ci skip]**
- **Fix a link with trailing slash that does not work [ci-skip]**
- **Fix link to docs in Composite Primary Keys guide**
- **Add a load hook for `ActiveRecord::DatabaseConfigurations`**
- **Sort schema cache columns and indexes per table when dumping**
- **Tweak `ActiveSupport::JSON.decode` method description**
- **Update form_helpers.md**
- **Fix a typo in the Active Record Query Interface guide**
- **[actionview] [Fix #54966] Check choice type before calling .second to detect grouped_choices in Select helper**
- **Clarify language and fix minor grammatical issues in Active Record Querying guide**
- **Set primary key insert default for insert_all and upsert_all**
- **Update Major Features section of release notes for Rails version 8.0**
- **Linting**
- **Fix typo in schema_statements.rb**
- **dep: bump trix to v2.1.14**
- **Implement ability to opt out of parallel database hooks**
- **Merge pull request #54993 from duffuniverse/fix-typos-in-multiple-databases-guide**
- **Add public API for `before_fork_hook` in parallel testing**
- **Rescue connection related errors in MemCacheStore#read_multi_entries**
- **Improve `#report` backtrace tests**
- **Support selenium-webdriver 4.32.0**
- **Skip Sidekiq 8.0.3**
- **Fix "ERROR [launcher.sauce]: Can not start safari latest"**
- **Use TRUE and FALSE for more SQLite queries**
- **Defer ActiveJob enqueue callbacks until after commit when enqueue_after_transaction_commit enabled**
- **Make the executor hooks in AR::QueryCache private**
- **Update guides on usage of --skip-solid flag to reflect latest information**
- **Test that `#report` sets the `cause`**
- **Enable passing retryable `SqlLiteral`s to `#where`**
- **Remove SqlLiteral re-wrapping from Arel.sql**
- **Update documentation for `create_join_table`**
- **[ci-skip][docs] Fix rich_text_area to rich_textarea in getting_started.md**
- **Update psych for ruby-head compatibility**
- **Declare dependency on `cgi`**
- **Fix typos in Active Record Encryption guide**
- **Only load from `cgi` what is required**
- **dep: bump trix to v2.1.15**
- **Fix duplicate items in action controller renderer docs**
- **Add some missing :nodoc:**
- **Update `set` gem for Ruby 3.5.0-dev compatibility**
- **Use inline queue adapter in bug report template**
- **Use default-mysql-client in Dockerfile for trilogy**
- **Add support for Cache-Control request directives**
- **Add note in  stating that  are not reported in the context of HTTP requests.**
- **Drop vendored Trix files in favor of the action_text-trix gem**
- **Fix `retry_job` instrumentation when using `:test` adapter for Active Job**
- **Fix affected_rows for SQLite sql.active_record notifications**
- **Fix `config.active_storage.touch_attachment_records` to work with eager loading**
- **Fix typos in The Asset Pipeline guide**
- **Fix typo on active record querying running explain**
- **Add affected_rows to ActiveRecord::Result**
- **[ci skip][docs] Keep Product model associations consistent**
- **Parallelize takes :number_of_processors as the option [ci skip]**
- **docs: Adding example to assert_difference method**
- **Prefer result.affected_rows over ivar**
- **Add support for multiple databases to `db:migrate:reset`.**
- **Updated ruby version devcontainer**
- **Avoid a module named `Namespace` for Ruby 3.5**
- **:class_name should be invalid in polymorphic belongs_to**
- **Register a4a1996 in the CHANGELOG**
- **add explicit mention to select replacement in pluck API docs**
- **Include Action Text pins in Import Maps section**
- **Prefer `.zero?` over `== 0` to match code extracted into a concern**
- **[RF-DOCS] Rails Application Template Guide - merge with Rails Generators Guide [ci-skip] (#55020)**
- **Update docs re :class_name and polymorphic associations**
- **Typo fix**
- **Restore :class_name in fixture**
- **Bump libxml-ruby to compile with GCC 15**
- **Document through + polymorphic**
- **Fix broken test when using rails-dom-testing 2.3:**
- **Improve docs through + polymorphic**
- **Fix docs of has_one :through associations**
- **Fix RDoc markup**
- **Memoize successful reflection cache validation**
- **Internal docs for the query cache store**
- **Remove unnecessary `ruby-version` input from `ruby/setup-ruby`**
- **Internal docs for the query cache registry**
- **Fix typos in Action Mailer Basics guide**
- **Active Job Continuations (#55127)**
- **Correct ActiveStorage guide phrasing**
- **Don't run unit tests within the System Tests GitHub Actions stage**
- **Always fully clear current attributes**
- **Load tests prior to when Minitest load plugins:**
- **Keep the original job object when using retry_job**
- **Fix grammar**
- **Get rid of an useless frame in AJ::Continuable#step**
- **[ci skip]Add missing `do |record|` to Active Job Continuation example**
- **Make job.instrument public with nodoc**
- **Avoid repeated calls to respond_to?**
- **Move Continuable jobs into the test case**
- **Remove redundant Continuable job prefixes**
- **Fix {Public,Debug}Exceptions body for HEAD**
- **Upload progress accounts for server processing time (#55157)**
- **Active Job Continuations continued (#55174)**
- **Add ability to change the transaction isolation for all pools within a block**
- **Temporarily pin devcontainer Ruby**
- **Fix affected_rows for SQLite adapter (again)**
- **[ci skip] Add warning note to :source_location tag option (#55167)**
- **Fix ActiveJob::Continuation documentation [ci skip]**
- **Simplify condition checks**
- **Print the record count in the generator guide template override example**
- **Fix `include?` on strict-loaded HABTM association**
- **Add CHANGELOG [ci skip] (#55198)**
- **Use ntuples to populate row_count instead of count for Postgres**
- **Translate `Trilogy::SSLError` to `ActiveRecord::ConnectionFailed`**
- **Remove documentation for non existing ColumnMethods#column [ci skip]**
- **Fix typo in with_recursive example**
- **Respect users configured `IRB.conf[:IRB_NAME]`**
- **Fix typos in Active Record Associations guide**
- **Implement ActiveSupport::BacktraceCleaner#first_clean_frame**
- **Ensure yarn and bun version fallback**
- **Refactor Generators::AppBase to avoid blind rescues**
- **Prevent the `stream_from` method throwing RuntimeError(can't add a new key into hash during iteration)**
- **Improve concurrent unsubscribe_from_channel test**
- **Fix typo in `The Request and Response Objects`**
- **FileUpdateChecker and EventedFileUpdateChecker ignore changes in Gem.path now.**
- **Implement ActiveSupport::BacktraceCleaner#first_clean_location**
- **Fix #55215 test failure**
- **Address TestERBTemplate test failure with Ruby 3.5.0dev**
- **Add locale options to PostgreSQL adapter DB create**
- **Active Job Continuation isolated steps (#55212)**
- **Fix link in guides for `assert_difference` method [ci skip]**
- **Allow for nested ExecutionContext in test**
- **Improve the docs of AS::BacktraceCleaner#first_clean_location**
- **Group methods under same Ruby constraints**
- **Moved LD_PRELOAD variable initialization to the Dockerfile from the entrypoint**
- **Implement ActiveSupport::BacktraceCleaner#clean_locations**
- **Fixes typo in CANGELOG**
- **Correctly name `CurrentAttributes` in CHANGELOG [ci skip]**
- **[ci skip] Add warning note to :source_location tag option (#55257)**
- **[RF-DOCS][ci skip] Update Threading and Code Execution Guide (#55179)**
- **Rails New: Only add browser restrictions when using importmap**
- **Revert "[RF-DOCS][ci skip] Update Threading and Code Execution Guide (#55179)"**
- **Fix use_big_decimal_serializer flag**
- **Revert workaround from #55182 and update to latest devcontainer image**
- **Improve XmlMini date parsing**
- **Add quotations for consistency with other envs**
- **Add `dom_target` helper to create `dom_id`-like strings from an unlimited number of objects**
- **Fix `remove_foreign_key` when multiple columns are found**
- **Cleanup `compatible_table_definition` methods**
- **Declare block param on NilClass#try and NilClass#try! (#55278)**
- **[Fix #53683] Reduce cache time for non-asset files in public dir**
- **Improve default public file server cache-control further**
- **Implement deprecated associations**
- **RDoc markup fix**
- **Delete extra blank line**
- **add rename_schema method for postgres**

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because [REPLACE ME]

### Detail

This Pull Request changes [REPLACE ME]

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
